### PR TITLE
Update generate-keys to be run on node and not pear

### DIFF
--- a/instructions.md
+++ b/instructions.md
@@ -48,7 +48,7 @@ One way to do this is:
     ```
 
 > [!TIP]
-> Retry the Docker commands above until you see the `hinter-core` ASCII art (related to [this issue](https://github.com/bbenligiray/hinter-core/issues/5)).
+> Retry the final Docker command until you see the `hinter-core` ASCII art (related to [this issue](https://github.com/bbenligiray/hinter-core/issues/5)).
 
 If the second Docker command prints the following, you can consider the installation complete and stop the container (for example, by closing the terminal):
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "docker:build": "docker build -t bbenligiray/hinter-core .",
     "docker:generate-keys": "docker run -it --rm -v /app/node_modules -v .:/app bbenligiray/hinter-core npm run generate-keys",
     "docker:start": "docker run -it --rm -v ./data/peers:/app/data/peers -v ./.env:/app/.env bbenligiray/hinter-core",
-    "generate-keys": "pear run src/generate-keys.js",
+    "generate-keys": "node src/generate-keys.js",
     "start": "pear run src/index.js"
   },
   "dependencies": {

--- a/src/generate-keys.js
+++ b/src/generate-keys.js
@@ -1,8 +1,5 @@
+import fs from 'fs';
 import crypto from 'hypercore-crypto';
-import fs from 'bare-fs';
-import { printAsciiArt } from './utils';
-
-printAsciiArt();
 
 if (fs.existsSync('.env')) {
     throw new Error('.env already exists!');


### PR DESCRIPTION
Alleviates https://github.com/bbenligiray/hinter-core/issues/5 since the first time user will have to retry a single Docker command rather than two