### PR TITLE
Implement peer size limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "docker:build": "docker build -t bbenligiray/hinter-core:latest .",
     "docker:build-and-push:multiplatform": "docker buildx build --platform linux/amd64,linux/arm64 -t bbenligiray/hinter-core:latest --push .",
     "docker:generate-keys": "docker run -it --rm -v /app/node_modules -v .:/app bbenligiray/hinter-core:latest npm run generate-keys",
-    "docker:start": "docker run -it --rm -v ./data/peers:/app/data/peers -v ./.env:/app/.env bbenligiray/hinter-core:latest",
+    "docker:start": "docker run -it --rm -v ./data/peers:/app/data/peers -v ./.env:/app/.env -v ./.storage:/app/.storage bbenligiray/hinter-core:latest",
     "generate-keys": "node src/generate-keys.js",
     "start": "pear run src/index.js"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -29,15 +29,15 @@ async function parseKeyPairFromEnv() {
     return keyPair;
 }
 
-
 async function main() {
     const keyPair = await parseKeyPairFromEnv();
     const peersDirectoryPath = path.join('data', 'peers');
     console.log('Parsing peers...');
-    const peers = await parsePeers(peersDirectoryPath);
+    const peerSizeLimitMB = parseInt(process.env.PEER_SIZE_LIMIT_MB || '1024');
+    const peers = await parsePeers(peersDirectoryPath, peerSizeLimitMB);
     console.log(`Parsed ${peers.length} peers!`);
     setInterval(async () => {
-        const currentPeers = await parsePeers(peersDirectoryPath);
+        const currentPeers = await parsePeers(peersDirectoryPath, peerSizeLimitMB);
         if (peers.map(peer => `${peer.alias}-${peer.publicKey}`).sort().toString() !== currentPeers.map(peer => `${peer.alias}-${peer.publicKey}`).sort().toString()) {
             console.log('Peers have changed. Exiting to allow restart.');
             process.exit(0);

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,10 @@ async function parseKeyPairFromEnv() {
 }
 
 async function parsePeers(peersDirectoryPath) {
-    console.log('Parsing peers...');
+    // Parse size limit from environment variable (default 1024MB = 1GB)
+    const sizeLimitMB = parseInt(process.env.PEER_SIZE_LIMIT_MB || '1024');
+    const sizeLimitBytes = sizeLimitMB * 1024 * 1024;
+    
     const peers = fs.readdirSync(peersDirectoryPath).map(peersFileName => {
         const peerDirectoryPath = path.join(peersDirectoryPath, peersFileName);
         if (!fs.statSync(peerDirectoryPath).isDirectory()) {
@@ -38,7 +41,16 @@ async function parsePeers(peersDirectoryPath) {
         if (!/^[^-]+-[a-f0-9]{64}$/.test(peersFileName)) {
             throw new Error(`${peersFileName} does not satisfy the ALIAS-PUBLIC_KEY format`);
         }
+        
         const [peerAlias, peerPublicKey] = peersFileName.split('-');
+        const blacklistFilePath = path.join(peerDirectoryPath, '.blacklisted');
+        
+        // Skip if peer is already blacklisted
+        if (fs.existsSync(blacklistFilePath)) {
+            console.log(`Skipping blacklisted peer: ${peerAlias}`);
+            return null;
+        }
+        
         const expectedPeerDirectoryNames = ['incoming', 'outgoing'];
         const peerDirectoryContents = fs.readdirSync(peerDirectoryPath);
         if (peerDirectoryContents.length !== expectedPeerDirectoryNames.length) {
@@ -52,16 +64,53 @@ async function parsePeers(peersDirectoryPath) {
                 throw new Error(`peers/${peerPublicKey}/${expectedPeerDirectoryName} is not a directory`);
             }
         });
+        
+        // Calculate incoming directory size
+        const incomingDirectoryPath = path.join(peerDirectoryPath, 'incoming');
+        let totalSize = 0;
+        
+        function calculateDirectorySize(dirPath) {
+            const items = fs.readdirSync(dirPath);
+            for (const item of items) {
+                const itemPath = path.join(dirPath, item);
+                const stats = fs.statSync(itemPath);
+                if (stats.isDirectory()) {
+                    calculateDirectorySize(itemPath);
+                } else {
+                    totalSize += stats.size;
+                }
+            }
+        }
+        
+        calculateDirectorySize(incomingDirectoryPath);
+        
+        // Check if peer exceeds size limit
+        if (totalSize > sizeLimitBytes) {
+            fs.writeFileSync(blacklistFilePath, '');
+            console.log(`Blacklisted peer ${peerAlias} for exceeding ${sizeLimitMB}MB limit (${Math.round(totalSize / 1024 / 1024)}MB used)`);
+            return { alias: peerAlias, publicKey: peerPublicKey, isBlacklisted: true };
+        }
+        
         return { alias: peerAlias, publicKey: peerPublicKey };
-    });
-    console.log(`Parsed ${peers.length} peers!`);
-    return peers;
+    }).filter(Boolean); // Remove null entries (already blacklisted peers)
+    
+    // Check for newly blacklisted peers and exit if any found
+    const blacklistedPeers = peers.filter(peer => peer.isBlacklisted);
+    if (blacklistedPeers.length > 0) {
+        const blacklistedAliases = blacklistedPeers.map(peer => peer.alias);
+        console.log(`Blacklisted peers: ${blacklistedAliases.join(', ')}. Exiting for restart.`);
+        process.exit(0);
+    }
+    
+    return peers.filter(peer => !peer.isBlacklisted);
 }
 
 async function main() {
     const keyPair = await parseKeyPairFromEnv();
     const peersDirectoryPath = path.join('data', 'peers');
+    console.log('Parsing peers...');
     const peers = await parsePeers(peersDirectoryPath);
+    console.log(`Parsed ${peers.length} peers!`);
     setInterval(async () => {
         const currentPeers = await parsePeers(peersDirectoryPath);
         if (peers.map(peer => `${peer.alias}-${peer.publicKey}`).sort().toString() !== currentPeers.map(peer => `${peer.alias}-${peer.publicKey}`).sort().toString()) {

--- a/src/index.js
+++ b/src/index.js
@@ -7,30 +7,10 @@ import Localdrive from 'localdrive';
 import Corestore from 'corestore';
 import crypto from 'hypercore-crypto';
 import b4a from 'b4a';
-import { printAsciiArt } from './utils';
+import { printAsciiArt, parseEnvFile } from './utils';
 import { parsePeers } from './peer.js';
 
 printAsciiArt();
-
-async function parseEnvFile() {
-    if (!fs.existsSync('.env')) {
-        throw new Error('Generate .env first!');
-    }
-    const envFileContent = fs.readFileSync('.env', 'utf8');
-    const keyPair = {
-        publicKey: b4a.from(envFileContent.match(/PUBLIC_KEY=([0-9a-f]+)/)[1], 'hex'),
-        secretKey: b4a.from(envFileContent.match(/SECRET_KEY=([0-9a-f]+)/)[1], 'hex')
-    };
-    if (!crypto.validateKeyPair(keyPair)) {
-        throw new Error('Key pair not valid');
-    }
-    const peerSizeLimitMatch = envFileContent.match(/PEER_SIZE_LIMIT_MB=(\d+)/);
-    const peerSizeLimitMB = peerSizeLimitMatch ? parseInt(peerSizeLimitMatch[1]) : undefined;
-    if (peerSizeLimitMB) {
-        console.log(`Parsed peer size limit: ${peerSizeLimitMB}MB`);
-    }
-    return { keyPair, peerSizeLimitMB };
-}
 
 async function main() {
     const { keyPair, peerSizeLimitMB: envFilePeerSizeLimitMB } = await parseEnvFile();

--- a/src/peer.js
+++ b/src/peer.js
@@ -48,9 +48,9 @@ export function parsePeers(peersDirectoryPath, peerSizeLimitMB) {
         return { alias: peerAlias, publicKey: peerPublicKey };
     }).filter(Boolean);
 
-    const blacklistedPeers = peers.filter(peer => peer.exceedsSizeLimit);
-    if (blacklistedPeers.length > 0) {
-        const blacklistedAliases = blacklistedPeers.map(peer => {
+    const peersToBlacklist = peers.filter(peer => peer.exceedsSizeLimit);
+    if (peersToBlacklist.length > 0) {
+        const blacklistedAliases = peersToBlacklist.map(peer => {
             fs.writeFileSync(path.join(peersDirectoryPath, `${peer.alias}-${peer.publicKey}`, '.blacklisted'), '');
             return peer.alias;
         });

--- a/src/peer.js
+++ b/src/peer.js
@@ -22,15 +22,12 @@ function validatePeerDirectory(peerDirectoryPath, peerDirectoryName) {
 
 function checkPeerSizeLimit(peerDirectoryPath, peerAlias, sizeLimitMB) {
     if (fs.existsSync(path.join(peerDirectoryPath, '.blacklisted'))) {
-        console.log(`Skipping blacklisted peer: ${peerAlias}`);
         return { isBlacklisted: true };
     }
     const incomingDirectorySize = calculateDirectorySize(path.join(peerDirectoryPath, 'incoming'));
-
     if (incomingDirectorySize > sizeLimitMB * 1024 * 1024) {
         return { isBlacklisted: false, exceedsSizeLimit: true };
     }
-
     return { isBlacklisted: false, exceedsSizeLimit: false };
 }
 

--- a/src/peer.js
+++ b/src/peer.js
@@ -1,0 +1,129 @@
+import fs from 'bare-fs';
+import path from 'bare-path';
+import process from 'bare-process';
+
+/**
+ * Recursively calculates the total size of a directory in bytes
+ */
+function calculateDirectorySize(dirPath) {
+    let totalSize = 0;
+    
+    function traverse(currentPath) {
+        const items = fs.readdirSync(currentPath);
+        for (const item of items) {
+            const itemPath = path.join(currentPath, item);
+            const stats = fs.statSync(itemPath);
+            if (stats.isDirectory()) {
+                traverse(itemPath);
+            } else {
+                totalSize += stats.size;
+            }
+        }
+    }
+    
+    traverse(dirPath);
+    return totalSize;
+}
+
+/**
+ * Validates peer directory structure and naming conventions
+ */
+function validatePeerDirectory(peerDirectoryPath, peersFileName) {
+    if (!fs.statSync(peerDirectoryPath).isDirectory()) {
+        throw new Error(`${peersFileName} is not a directory`);
+    }
+    
+    if (!/^[^-]+-[a-f0-9]{64}$/.test(peersFileName)) {
+        throw new Error(`${peersFileName} does not satisfy the ALIAS-PUBLIC_KEY format`);
+    }
+    
+    const [peerAlias, peerPublicKey] = peersFileName.split('-');
+    
+    const expectedPeerDirectoryNames = ['incoming', 'outgoing'];
+    const peerDirectoryContents = fs.readdirSync(peerDirectoryPath);
+    
+    if (peerDirectoryContents.length !== expectedPeerDirectoryNames.length) {
+        throw new Error(`Unexpected number of contents in peers/${peerPublicKey}`);
+    }
+    
+    expectedPeerDirectoryNames.forEach(expectedPeerDirectoryName => {
+        if (!peerDirectoryContents.includes(expectedPeerDirectoryName)) {
+            throw new Error(`Missing ${expectedPeerDirectoryName} in peers/${peerPublicKey}`);
+        }
+        if (!fs.statSync(path.join(peerDirectoryPath, expectedPeerDirectoryName)).isDirectory()) {
+            throw new Error(`peers/${peerPublicKey}/${expectedPeerDirectoryName} is not a directory`);
+        }
+    });
+    
+    return { peerAlias, peerPublicKey };
+}
+
+/**
+ * Checks peer size limit and handles blacklisting if exceeded
+ */
+function checkPeerSizeLimit(peerDirectoryPath, peerAlias, peerPublicKey, sizeLimitBytes, sizeLimitMB) {
+    const blacklistFilePath = path.join(peerDirectoryPath, '.blacklisted');
+    
+    // Skip if peer is already blacklisted
+    if (fs.existsSync(blacklistFilePath)) {
+        console.log(`Skipping blacklisted peer: ${peerAlias}`);
+        return { isBlacklisted: true, isAlreadyBlacklisted: true };
+    }
+    
+    // Calculate incoming directory size
+    const incomingDirectoryPath = path.join(peerDirectoryPath, 'incoming');
+    const totalSize = calculateDirectorySize(incomingDirectoryPath);
+    
+    // Check if peer exceeds size limit
+    if (totalSize > sizeLimitBytes) {
+        fs.writeFileSync(blacklistFilePath, '');
+        console.log(`Blacklisted peer ${peerAlias} for exceeding ${sizeLimitMB}MB limit (${Math.round(totalSize / 1024 / 1024)}MB used)`);
+        return { isBlacklisted: true, isAlreadyBlacklisted: false };
+    }
+    
+    return { isBlacklisted: false, isAlreadyBlacklisted: false };
+}
+
+/**
+ * Parses peers from the specified directory, handling validation, size limits, and blacklisting
+ */
+export function parsePeers(peersDirectoryPath) {
+    // Parse size limit from environment variable (default 1024MB = 1GB)
+    const sizeLimitMB = parseInt(process.env.PEER_SIZE_LIMIT_MB || '1024');
+    const sizeLimitBytes = sizeLimitMB * 1024 * 1024;
+    
+    const peers = fs.readdirSync(peersDirectoryPath).map(peersFileName => {
+        const peerDirectoryPath = path.join(peersDirectoryPath, peersFileName);
+        
+        try {
+            // Validate peer directory structure
+            const { peerAlias, peerPublicKey } = validatePeerDirectory(peerDirectoryPath, peersFileName);
+            
+            // Check size limits and blacklisting
+            const sizeCheckResult = checkPeerSizeLimit(peerDirectoryPath, peerAlias, peerPublicKey, sizeLimitBytes, sizeLimitMB);
+            
+            if (sizeCheckResult.isAlreadyBlacklisted) {
+                return null; // Skip already blacklisted peers
+            }
+            
+            if (sizeCheckResult.isBlacklisted) {
+                return { alias: peerAlias, publicKey: peerPublicKey, isBlacklisted: true };
+            }
+            
+            return { alias: peerAlias, publicKey: peerPublicKey };
+            
+        } catch (error) {
+            throw error; // Re-throw validation errors
+        }
+    }).filter(Boolean); // Remove null entries (already blacklisted peers)
+    
+    // Check for newly blacklisted peers and exit if any found
+    const blacklistedPeers = peers.filter(peer => peer.isBlacklisted);
+    if (blacklistedPeers.length > 0) {
+        const blacklistedAliases = blacklistedPeers.map(peer => peer.alias);
+        console.log(`Blacklisted peers: ${blacklistedAliases.join(', ')}. Exiting for restart.`);
+        process.exit(0);
+    }
+    
+    return peers.filter(peer => !peer.isBlacklisted);
+}

--- a/src/peer.js
+++ b/src/peer.js
@@ -1,129 +1,65 @@
 import fs from 'bare-fs';
 import path from 'bare-path';
 import process from 'bare-process';
+import { calculateDirectorySize } from './utils';
 
-/**
- * Recursively calculates the total size of a directory in bytes
- */
-function calculateDirectorySize(dirPath) {
-    let totalSize = 0;
-    
-    function traverse(currentPath) {
-        const items = fs.readdirSync(currentPath);
-        for (const item of items) {
-            const itemPath = path.join(currentPath, item);
-            const stats = fs.statSync(itemPath);
-            if (stats.isDirectory()) {
-                traverse(itemPath);
-            } else {
-                totalSize += stats.size;
-            }
-        }
+function validatePeerDirectory(peerDirectoryPath, peerDirectoryName) {
+    if (!/^[^-]+-[a-f0-9]{64}$/.test(peerDirectoryName)) {
+        throw new Error(`${peerDirectoryName} does not satisfy the ALIAS-PUBLIC_KEY format`);
     }
-    
-    traverse(dirPath);
-    return totalSize;
-}
 
-/**
- * Validates peer directory structure and naming conventions
- */
-function validatePeerDirectory(peerDirectoryPath, peersFileName) {
-    if (!fs.statSync(peerDirectoryPath).isDirectory()) {
-        throw new Error(`${peersFileName} is not a directory`);
-    }
-    
-    if (!/^[^-]+-[a-f0-9]{64}$/.test(peersFileName)) {
-        throw new Error(`${peersFileName} does not satisfy the ALIAS-PUBLIC_KEY format`);
-    }
-    
-    const [peerAlias, peerPublicKey] = peersFileName.split('-');
-    
-    const expectedPeerDirectoryNames = ['incoming', 'outgoing'];
-    const peerDirectoryContents = fs.readdirSync(peerDirectoryPath);
-    
-    if (peerDirectoryContents.length !== expectedPeerDirectoryNames.length) {
-        throw new Error(`Unexpected number of contents in peers/${peerPublicKey}`);
-    }
-    
-    expectedPeerDirectoryNames.forEach(expectedPeerDirectoryName => {
-        if (!peerDirectoryContents.includes(expectedPeerDirectoryName)) {
-            throw new Error(`Missing ${expectedPeerDirectoryName} in peers/${peerPublicKey}`);
-        }
-        if (!fs.statSync(path.join(peerDirectoryPath, expectedPeerDirectoryName)).isDirectory()) {
-            throw new Error(`peers/${peerPublicKey}/${expectedPeerDirectoryName} is not a directory`);
+    ['incoming', 'outgoing'].forEach(expectedPeerDirectoryName => {
+        const expectedPeerDirectoryPath = path.join(peerDirectoryPath, expectedPeerDirectoryName);
+        fs.mkdirSync(expectedPeerDirectoryPath, { recursive: true });
+        if (!fs.statSync(expectedPeerDirectoryPath).isDirectory()) {
+            throw new Error(`${expectedPeerDirectoryPath} is not a directory`);
         }
     });
-    
+
+    const [peerAlias, peerPublicKey] = peerDirectoryName.split('-');
     return { peerAlias, peerPublicKey };
 }
 
-/**
- * Checks peer size limit and handles blacklisting if exceeded
- */
-function checkPeerSizeLimit(peerDirectoryPath, peerAlias, peerPublicKey, sizeLimitBytes, sizeLimitMB) {
-    const blacklistFilePath = path.join(peerDirectoryPath, '.blacklisted');
-    
-    // Skip if peer is already blacklisted
-    if (fs.existsSync(blacklistFilePath)) {
+function checkPeerSizeLimit(peerDirectoryPath, peerAlias, sizeLimitMB) {
+    if (fs.existsSync(path.join(peerDirectoryPath, '.blacklisted'))) {
         console.log(`Skipping blacklisted peer: ${peerAlias}`);
-        return { isBlacklisted: true, isAlreadyBlacklisted: true };
+        return { isBlacklisted: true };
     }
-    
-    // Calculate incoming directory size
-    const incomingDirectoryPath = path.join(peerDirectoryPath, 'incoming');
-    const totalSize = calculateDirectorySize(incomingDirectoryPath);
-    
-    // Check if peer exceeds size limit
-    if (totalSize > sizeLimitBytes) {
-        fs.writeFileSync(blacklistFilePath, '');
-        console.log(`Blacklisted peer ${peerAlias} for exceeding ${sizeLimitMB}MB limit (${Math.round(totalSize / 1024 / 1024)}MB used)`);
-        return { isBlacklisted: true, isAlreadyBlacklisted: false };
+    const incomingDirectorySize = calculateDirectorySize(path.join(peerDirectoryPath, 'incoming'));
+
+    if (incomingDirectorySize > sizeLimitMB * 1024 * 1024) {
+        return { isBlacklisted: false, exceedsSizeLimit: true };
     }
-    
-    return { isBlacklisted: false, isAlreadyBlacklisted: false };
+
+    return { isBlacklisted: false, exceedsSizeLimit: false };
 }
 
-/**
- * Parses peers from the specified directory, handling validation, size limits, and blacklisting
- */
-export function parsePeers(peersDirectoryPath) {
-    // Parse size limit from environment variable (default 1024MB = 1GB)
-    const sizeLimitMB = parseInt(process.env.PEER_SIZE_LIMIT_MB || '1024');
-    const sizeLimitBytes = sizeLimitMB * 1024 * 1024;
-    
-    const peers = fs.readdirSync(peersDirectoryPath).map(peersFileName => {
-        const peerDirectoryPath = path.join(peersDirectoryPath, peersFileName);
-        
-        try {
-            // Validate peer directory structure
-            const { peerAlias, peerPublicKey } = validatePeerDirectory(peerDirectoryPath, peersFileName);
-            
-            // Check size limits and blacklisting
-            const sizeCheckResult = checkPeerSizeLimit(peerDirectoryPath, peerAlias, peerPublicKey, sizeLimitBytes, sizeLimitMB);
-            
-            if (sizeCheckResult.isAlreadyBlacklisted) {
-                return null; // Skip already blacklisted peers
-            }
-            
-            if (sizeCheckResult.isBlacklisted) {
-                return { alias: peerAlias, publicKey: peerPublicKey, isBlacklisted: true };
-            }
-            
-            return { alias: peerAlias, publicKey: peerPublicKey };
-            
-        } catch (error) {
-            throw error; // Re-throw validation errors
+export function parsePeers(peersDirectoryPath, peerSizeLimitMB) {
+    const peers = fs.readdirSync(peersDirectoryPath).map(peerDirectoryName => {
+        const peerDirectoryPath = path.join(peersDirectoryPath, peerDirectoryName);
+        if (!fs.statSync(peerDirectoryPath).isDirectory()) {
+            throw new Error(`${peerDirectoryName} is not a directory`);
         }
-    }).filter(Boolean); // Remove null entries (already blacklisted peers)
-    
-    // Check for newly blacklisted peers and exit if any found
-    const blacklistedPeers = peers.filter(peer => peer.isBlacklisted);
+        const { peerAlias, peerPublicKey } = validatePeerDirectory(peerDirectoryPath, peerDirectoryName);
+        const sizeCheckResult = checkPeerSizeLimit(peerDirectoryPath, peerAlias, peerSizeLimitMB);
+        if (sizeCheckResult.isBlacklisted) {
+            return null;
+        }
+        if (sizeCheckResult.exceedsSizeLimit) {
+            return { alias: peerAlias, publicKey: peerPublicKey, exceedsSizeLimit: true };
+        }
+        return { alias: peerAlias, publicKey: peerPublicKey };
+    }).filter(Boolean);
+
+    const blacklistedPeers = peers.filter(peer => peer.exceedsSizeLimit);
     if (blacklistedPeers.length > 0) {
-        const blacklistedAliases = blacklistedPeers.map(peer => peer.alias);
-        console.log(`Blacklisted peers: ${blacklistedAliases.join(', ')}. Exiting for restart.`);
+        const blacklistedAliases = blacklistedPeers.map(peer => {
+            fs.writeFileSync(path.join(peersDirectoryPath, `${peer.alias}-${peer.publicKey}`, '.blacklisted'), '');
+            return peer.alias;
+        });
+        console.log(`Peers blacklisted for exceeding the size limit: ${blacklistedAliases.join(', ')}. Exiting for restart.`);
         process.exit(0);
     }
-    
+
     return peers.filter(peer => !peer.isBlacklisted);
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,6 @@
+import fs from 'bare-fs';
+import path from 'bare-path';
+
 export function printAsciiArt() {
     console.log(
         '  _     _       _                                     \n',

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,3 +9,23 @@ export function printAsciiArt() {
         '                                                     \n'
     );
 }
+
+export function calculateDirectorySize(dirPath) {
+    let totalSize = 0;
+
+    function traverse(currentPath) {
+        const items = fs.readdirSync(currentPath);
+        for (const item of items) {
+            const itemPath = path.join(currentPath, item);
+            const stats = fs.statSync(itemPath);
+            if (stats.isDirectory()) {
+                traverse(itemPath);
+            } else {
+                totalSize += stats.size;
+            }
+        }
+    }
+
+    traverse(dirPath);
+    return totalSize;
+}


### PR DESCRIPTION
Closes https://github.com/bbenligiray/hinter-core/issues/3 with a default 1GB per-peer limit that can be customized globally through the new `.env` option, `PEER_SIZE_LIMIT_MB`