### PR TITLE
Add a global config file

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -3,12 +3,6 @@ name: End-to-End Test
 on:
   workflow_dispatch:
 
-env:
-  HINTER1_PUBLIC_KEY: 1720090ca74ba7c5100c5c9bf7898171fbae0ede675fa7c3aa248bd1d6c96a8f
-  HINTER1_SECRET_KEY: a580f4d154155ff2947855b7770435015c111bb5e1ae31b0915bded7d9b1ecbb1720090ca74ba7c5100c5c9bf7898171fbae0ede675fa7c3aa248bd1d6c96a8f
-  HINTER2_PUBLIC_KEY: 9e230ac8b403f3861871c2325f3226c930e7e4f0809b6633a6870aa05904ef01
-  HINTER2_SECRET_KEY: 0646dadeeaf79af9aab9954d7c63a52fa2ee1e1c04276cc0b760c6dd5c920d899e230ac8b403f3861871c2325f3226c930e7e4f0809b6633a6870aa05904ef01
-
 jobs:
   hinter1:
     runs-on: ubuntu-latest
@@ -23,9 +17,9 @@ jobs:
         run: |
           mkdir -p hinter-core-data/peers/hinter2/outgoing
           mkdir -p hinter-core-data/peers/hinter2/incoming
-          echo "{\"publicKey\":\"${HINTER2_PUBLIC_KEY}\"}" > hinter-core-data/peers/hinter2/hinter.config.json
-          echo "PUBLIC_KEY=${HINTER1_PUBLIC_KEY}" > hinter-core-data/.env
-          echo "SECRET_KEY=${HINTER1_SECRET_KEY}" >> hinter-core-data/.env
+          echo "{\"publicKey\":\"9e230ac8b403f3861871c2325f3226c930e7e4f0809b6633a6870aa05904ef01\"}" > hinter-core-data/peers/hinter2/hinter.config.json
+          echo "PUBLIC_KEY=1720090ca74ba7c5100c5c9bf7898171fbae0ede675fa7c3aa248bd1d6c96a8f" > hinter-core-data/.env
+          echo "SECRET_KEY=a580f4d154155ff2947855b7770435015c111bb5e1ae31b0915bded7d9b1ecbb1720090ca74ba7c5100c5c9bf7898171fbae0ede675fa7c3aa248bd1d6c96a8f" >> hinter-core-data/.env
 
       - name: Run hinter-core in background
         run: docker run -d --name hinter1 --network host -v "$(pwd)/hinter-core-data:/app/hinter-core-data" hinter-core:test
@@ -76,9 +70,9 @@ jobs:
         run: |
           mkdir -p hinter-core-data/peers/hinter1/outgoing
           mkdir -p hinter-core-data/peers/hinter1/incoming
-          echo "{\"publicKey\":\"${HINTER1_PUBLIC_KEY}\"}" > hinter-core-data/peers/hinter1/hinter.config.json
-          echo "PUBLIC_KEY=${HINTER2_PUBLIC_KEY}" > hinter-core-data/.env
-          echo "SECRET_KEY=${HINTER2_SECRET_KEY}" >> hinter-core-data/.env
+          echo "{\"publicKey\":\"1720090ca74ba7c5100c5c9bf7898171fbae0ede675fa7c3aa248bd1d6c96a8f\"}" > hinter-core-data/peers/hinter1/hinter.config.json
+          echo "PUBLIC_KEY=9e230ac8b403f3861871c2325f3226c930e7e4f0809b6633a6870aa05904ef01" > hinter-core-data/.env
+          echo "SECRET_KEY=0646dadeeaf79af9aab9954d7c63a52fa2ee1e1c04276cc0b760c6dd5c920d899e230ac8b403f3861871c2325f3226c930e7e4f0809b6633a6870aa05904ef01" >> hinter-core-data/.env
 
       - name: Run hinter-core in background
         run: docker run -d --name hinter2 --network host -v "$(pwd)/hinter-core-data:/app/hinter-core-data" hinter-core:test

--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@ See [instructions](./instructions.md) to run `hinter-core` in a Docker container
 
 The `hinter-core-data/` directory, which stores your peer configurations, shared data and cryptographic keypair, will be created when you run the initialization script mentioned in the installation instructions.
 
+### Directory Structure
+
 ```
 hinter-core-data/
 ├── .env                                # Your keypair
+├── hinter.config.json                  # Global configuration (optional)
 └── peers/
      ├── {PEER_ALIAS_1}/                # Report directory of peer #1
      │    ├── hinter.config.json        # Configuration for peer #1
@@ -20,22 +23,31 @@ hinter-core-data/
      │    │    └── **                   # Incoming reports from peer #1 to you
      │    └── outgoing/
      │         └── **                   # Outgoing reports from you to peer #1
-     ├── {PEER_ALIAS_2}/                # Report directory of peer #2
-     │    ├── hinter.config.json        # Configuration for peer #2
-     │    ├── incoming/
-     │    │    └── **                   # Incoming reports from peer #2 to you
-     │    └── outgoing/
-     │         └── **                   # Outgoing reports from you to peer #2
      └──  **/                           # Report directories of additional peers
 ```
 
-### Required peer-specific `hinter.config.json` file
+### Configuration
 
-Each peer directory includes a `hinter.config.json` with the public key of the peer and additional optional parameters as required by sidecar applications such as [`hinter-cline`.](https://github.com/bbenligiray/hinter-cline)
+Configuration is handled by `hinter.config.json` files. A global configuration file can be placed at `hinter-core-data/hinter.config.json`, and peer-specific settings can be configured in `hinter-core-data/peers/{PEER_ALIAS}/hinter.config.json`.
+
+Peer-specific settings override global settings.
+
+#### Global Configuration
+
+The global `hinter.config.json` file can contain the following optional keys:
+
+*   `peerSizeLimitMB` (default: `1024`): The maximum size of a peer's incoming directory in megabytes before they get blacklisted.
+*   `disableIncomingReports` (default: `false`): When set to `true`, the application will not receive reports from any peers.
+
+#### Peer-Specific Configuration
+
+The peer-specific `hinter.config.json` file must contain the `publicKey` of the peer.
+It can also override any of the global configuration settings.
 
 ```json
 {
-  "publicKey": "45a2...",
-  ...
+  "publicKey": "...",
+  "peerSizeLimitMB": 2048,
+  "disableIncomingReports": true
 }
 ```

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,50 @@
+import fs from 'bare-fs';
+import path from 'bare-path';
+
+const globalConfigDefaults = {
+    peerSizeLimitMB: 1024,
+    disableIncomingReports: false
+};
+
+export function parseGlobalConfig() {
+    const globalConfigPath = path.join('hinter-core-data', 'hinter.config.json');
+    const config = { ...globalConfigDefaults };
+
+    // Unlike the peer config file, the global config file is optional
+    if (fs.existsSync(globalConfigPath)) {
+        const globalConfig = JSON.parse(fs.readFileSync(globalConfigPath, 'utf-8'));
+        // We allow sidecar applications to overload the global config schema
+        for (const key in globalConfigDefaults) {
+            if (globalConfig[key] !== undefined) {
+                // Type validation would be nice here but we don't want more dependencies
+                config[key] = globalConfig[key];
+            }
+        }
+    }
+
+    return config;
+}
+
+export function parsePeerConfig(peerDirectoryPath, globalConfig) {
+    const configPath = path.join(peerDirectoryPath, 'hinter.config.json');
+    if (!fs.existsSync(configPath)) {
+        throw new Error(`hinter.config.json not found in ${peerDirectoryPath}`);
+    }
+
+    const peerConfig = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+
+    if (!peerConfig.publicKey || !/^[a-f0-9]{64}$/.test(peerConfig.publicKey)) {
+        throw new Error(`Invalid or missing publicKey in ${configPath}`);
+    }
+
+    const config = { ...globalConfig, publicKey: peerConfig.publicKey };
+
+    // Similar to global config, we allow sidecar applications to overload the peer config schema
+    for (const key in globalConfigDefaults) {
+        if (peerConfig[key] !== undefined) {
+            config[key] = peerConfig[key];
+        }
+    }
+
+    return config;
+}

--- a/src/config.js
+++ b/src/config.js
@@ -13,7 +13,7 @@ export function parseGlobalConfig() {
     // Unlike the peer config file, the global config file is optional
     if (fs.existsSync(globalConfigPath)) {
         const globalConfig = JSON.parse(fs.readFileSync(globalConfigPath, 'utf-8'));
-        // We allow sidecar applications to overload the global config schema
+        // We allow companion applications to overload the global config schema
         for (const key in globalConfigDefaults) {
             if (globalConfig[key] !== undefined) {
                 // Type validation would be nice here but we don't want more dependencies
@@ -39,7 +39,7 @@ export function parsePeerConfig(peerDirectoryPath, globalConfig) {
 
     const config = { ...globalConfig, publicKey: peerConfig.publicKey };
 
-    // Similar to global config, we allow sidecar applications to overload the peer config schema
+    // Similar to global config, we allow companion applications to overload the peer config schema
     for (const key in globalConfigDefaults) {
         if (peerConfig[key] !== undefined) {
             config[key] = peerConfig[key];

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ async function main() {
     const peersDirectoryPath = path.join('hinter-core-data', 'peers');
     console.log('Parsing peers...');
     const initialPeers = await parsePeers(peersDirectoryPath, globalConfig);
-    // Clone initialPeers because we will be adding dynamic elements to it
+    // Clone initialPeers to be able to add dynamic elements to it
     const peers = structuredClone(initialPeers);
     console.log(`Parsed ${initialPeers.length} peers!`);
     setInterval(async () => {

--- a/src/peer.js
+++ b/src/peer.js
@@ -2,55 +2,49 @@ import fs from 'bare-fs';
 import path from 'bare-path';
 import process from 'bare-process';
 import { calculateDirectorySize } from './utils';
+import { parsePeerConfig } from './config';
 
-function validatePeerDirectory(peerDirectoryPath) {
-    const configPath = path.join(peerDirectoryPath, 'hinter.config.json');
-    if (!fs.existsSync(configPath)) {
-        throw new Error(`hinter.config.json not found in ${peerDirectoryPath}`);
-    }
-
-    const publicKey = JSON.parse(fs.readFileSync(configPath, 'utf-8')).publicKey;
-    if (!publicKey || !/^[a-f0-9]{64}$/.test(publicKey)) {
-        throw new Error(`Invalid or missing publicKey in ${configPath}`);
-    }
-
-    ['incoming', 'outgoing'].forEach(expectedPeerDirectoryName => {
-        const expectedPeerDirectoryPath = path.join(peerDirectoryPath, expectedPeerDirectoryName);
-        fs.mkdirSync(expectedPeerDirectoryPath, { recursive: true });
-        if (!fs.statSync(expectedPeerDirectoryPath).isDirectory()) {
-            throw new Error(`${expectedPeerDirectoryPath} is not a directory`);
-        }
-    });
-
-    return { peerAlias: path.basename(peerDirectoryPath), peerPublicKey: publicKey };
-}
-
-function checkPeerSizeLimit(peerDirectoryPath, peerAlias, sizeLimitMB) {
+function checkPeerSizeLimit(peerDirectoryPath, peer) {
+    // Saving some compute by not calling calculateDirectorySize() on already blacklisted peers
     if (fs.existsSync(path.join(peerDirectoryPath, '.blacklisted'))) {
         return { isBlacklisted: true };
     }
     const incomingDirectorySize = calculateDirectorySize(path.join(peerDirectoryPath, 'incoming'));
-    if (incomingDirectorySize > sizeLimitMB * 1024 * 1024) {
+    if (incomingDirectorySize > peer.peerSizeLimitMB * 1024 * 1024) {
         return { isBlacklisted: false, exceedsSizeLimit: true };
     }
     return { isBlacklisted: false, exceedsSizeLimit: false };
 }
 
-export function parsePeers(peersDirectoryPath, peerSizeLimitMB) {
+export function parsePeers(peersDirectoryPath, globalConfig) {
     const peers = fs.readdirSync(peersDirectoryPath).map(peerDirectoryName => {
         const peerDirectoryPath = path.join(peersDirectoryPath, peerDirectoryName);
+        // Tolerate files like .DS_STORE
         if (!fs.statSync(peerDirectoryPath).isDirectory()) {
             return null;
         }
-        const { peerAlias, peerPublicKey } = validatePeerDirectory(peerDirectoryPath);
-        const sizeCheckResult = checkPeerSizeLimit(peerDirectoryPath, peerAlias, peerSizeLimitMB);
+
+        const peer = parsePeerConfig(peerDirectoryPath, globalConfig);
+        peer.alias = path.basename(peerDirectoryPath);
+
+        ['incoming', 'outgoing'].forEach(expectedPeerDirectoryName => {
+            const expectedPeerDirectoryPath = path.join(peerDirectoryPath, expectedPeerDirectoryName);
+            fs.mkdirSync(expectedPeerDirectoryPath, { recursive: true });
+            // Unlikely, but there may already be files (not directories) named incoming or outgoing in the peer directory 
+            if (!fs.statSync(expectedPeerDirectoryPath).isDirectory()) {
+                throw new Error(`${expectedPeerDirectoryPath} is not a directory`);
+            }
+        });
+
+        const sizeCheckResult = checkPeerSizeLimit(peerDirectoryPath, peer);
+        // Have blacklisted peers are ignored by the .filter(Boolean)
         if (sizeCheckResult.isBlacklisted) {
             return null;
         }
         if (sizeCheckResult.exceedsSizeLimit) {
-            return { alias: peerAlias, publicKey: peerPublicKey, exceedsSizeLimit: true };
+            peer.exceedsSizeLimit = true;
         }
-        return { alias: peerAlias, publicKey: peerPublicKey };
+        return peer;
     }).filter(Boolean);
 
     const peersToBlacklist = peers.filter(peer => peer.exceedsSizeLimit);
@@ -63,5 +57,5 @@ export function parsePeers(peersDirectoryPath, peerSizeLimitMB) {
         process.exit(0);
     }
 
-    return peers.filter(peer => !peer.isBlacklisted);
+    return peers;
 }

--- a/src/peer.js
+++ b/src/peer.js
@@ -37,7 +37,7 @@ export function parsePeers(peersDirectoryPath, globalConfig) {
         });
 
         const sizeCheckResult = checkPeerSizeLimit(peerDirectoryPath, peer);
-        // Have blacklisted peers are ignored by the .filter(Boolean)
+        // Have blacklisted peers be ignored by the .filter(Boolean) below
         if (sizeCheckResult.isBlacklisted) {
             return null;
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -48,17 +48,6 @@ export async function parseEnvFile() {
     if (!crypto.validateKeyPair(keyPair)) {
         throw new Error('Key pair not valid');
     }
-    const peerSizeLimitMatch = envFileContent.match(/PEER_SIZE_LIMIT_MB=(\d+)/);
-    const peerSizeLimitMB = peerSizeLimitMatch ? parseInt(peerSizeLimitMatch[1]) : undefined;
-    if (peerSizeLimitMB) {
-        console.log(`Parsed peer size limit: ${peerSizeLimitMB}MB`);
-    }
     
-    const disableIncomingReportsMatch = envFileContent.match(/DISABLE_INCOMING_REPORTS=(true|false)/);
-    const disableIncomingReports = disableIncomingReportsMatch ? disableIncomingReportsMatch[1] === 'true' : undefined;
-    if (disableIncomingReports) {
-        console.log('Incoming reports disabled - running in send-only mode');
-    }
-    
-    return { keyPair, peerSizeLimitMB, disableIncomingReports };
+    return { keyPair };
 }


### PR DESCRIPTION
Closes https://github.com/bbenligiray/hinter-core/issues/62 and https://github.com/bbenligiray/hinter-core/issues/30

Adds a global config file that is overrideable by peer-specific config files. One thing to note is that although both the global config file and the peer-specific config file share the same name (`hinter.config.json`), their schemas are different (the peer-specific config file requires a `publicKey` entry while the global one doesn't require it and ignore it if it exists). This is similar to how `.gitconfig` can be user-specific or repo-specific, while the `remote.origin.url` entry would only make sense for the repo-specific version (and it's ignored even if defined in the user-specific version).

The implementation enables sidecar applications such as hinter-cline to override hinter.config.json to add their own global/peer-specific parameters